### PR TITLE
Add basic testing and lint setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm install
+      - run: npm run lint
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -124,6 +124,13 @@ If you used the automated provisioning tool, a `teardown.sh` script is provided 
 1.  Make sure the `gcp_project_id` in your `setup.conf` file points to the project you want to delete.
 2.  Run the script from your terminal: `./teardown.sh`
 
+## Development
+
+This repository now includes a minimal test and lint setup to aid development.
+
+- Run `npm run lint` to perform a syntax check on the Apps Script sources.
+- Run `npm test` to execute unit tests for utility functions.
+
 ---
 
 ## Advanced Features

--- a/apps_script_project/Code.js
+++ b/apps_script_project/Code.js
@@ -252,7 +252,7 @@ function syncUserGroups() {
 
         // Generate group email if it doesn't exist
         if (!groupEmail) {
-          groupEmail = generateGroupEmail_(groupName);
+          groupEmail = generateGroupEmail(groupName);
           groupEmailCell.setValue(groupEmail);
           log_('Generated group email for ' + groupName + ': ' + groupEmail);
         }
@@ -390,7 +390,7 @@ function processRow_(rowIndex) {
     sheet.getRange(rowIndex, FOLDER_NAME_COL).setValue(folder.getName());
 
     const userSheetName = folder.getName() + '_' + role;
-    const groupEmail = generateGroupEmail_(userSheetName);
+    const groupEmail = generateGroupEmail(userSheetName);
     sheet.getRange(rowIndex, USER_SHEET_NAME_COL).setValue(userSheetName);
     sheet.getRange(rowIndex, GROUP_EMAIL_COL).setValue(groupEmail);
 
@@ -760,21 +760,6 @@ function setSheetUiStyles_() {
     log_('Could not apply UI styles. Error: ' + e.message, 'WARN');
   }
 }
-
-function generateGroupEmail_(baseName) {
-  const domain = Session.getActiveUser().getEmail().split('@')[1];
-  if (!domain) {
-    throw new Error('Could not determine user domain.');
-  }
-  
-  const sanitizedName = baseName
-    .toLowerCase()
-    .replace(/\s+/g, '-')
-    .replace(/[^a-z0-9-]/g, '');
-
-  return sanitizedName + '@' + domain;
-}
-
 
 /***** DEVELOPER-ONLY TEST FUNCTIONS *****/
 
@@ -1358,7 +1343,7 @@ function processRow_(rowIndex) {
     sheet.getRange(rowIndex, FOLDER_NAME_COL).setValue(folder.getName());
 
     const userSheetName = folder.getName() + '_' + role;
-    const groupEmail = generateGroupEmail_(userSheetName);
+    const groupEmail = generateGroupEmail(userSheetName);
     sheet.getRange(rowIndex, USER_SHEET_NAME_COL).setValue(userSheetName);
     sheet.getRange(rowIndex, GROUP_EMAIL_COL).setValue(groupEmail);
 
@@ -1728,21 +1713,6 @@ function setSheetUiStyles_() {
     log_('Could not apply UI styles. Error: ' + e.message);
   }
 }
-
-function generateGroupEmail_(baseName) {
-  const domain = Session.getActiveUser().getEmail().split('@')[1];
-  if (!domain) {
-    throw new Error('Could not determine user domain.');
-  }
-  
-  const sanitizedName = baseName
-    .toLowerCase()
-    .replace(/\s+/g, '-')
-    .replace(/[^a-z0-9-]/g, '');
-
-  return sanitizedName + '@' + domain;
-}
-
 
 /***** DEVELOPER-ONLY TEST FUNCTIONS *****/
 

--- a/apps_script_project/utils.js
+++ b/apps_script_project/utils.js
@@ -1,0 +1,15 @@
+function generateGroupEmail(baseName, domain) {
+  const domainToUse = domain || Session.getActiveUser().getEmail().split('@')[1];
+  if (!domainToUse) {
+    throw new Error('Could not determine user domain.');
+  }
+  const sanitizedName = baseName
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9-]/g, '');
+  return sanitizedName + '@' + domainToUse;
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { generateGroupEmail };
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "gdrive_permissions1",
+  "version": "1.0.0",
+  "description": "> **Project Status: Beta** > > This project is currently in Beta. It is feature-complete and has been tested, but it is still under active development. Please use it with the understanding that there may be bugs or changes to the functionality. Feedback and contributions are welcome!",
+  "main": "index.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "test": "node tests/utils.test.js",
+    "lint": "node --check apps_script_project/utils.js apps_script_project/Code.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,0 +1,35 @@
+const assert = require('assert');
+const { generateGroupEmail } = require('../apps_script_project/utils.js');
+
+describe('generateGroupEmail', () => {
+  it('sanitizes name and appends domain', () => {
+    const result = generateGroupEmail('My Group Name', 'example.com');
+    assert.strictEqual(result, 'my-group-name@example.com');
+  });
+
+  it('throws if domain missing and Session not provided', () => {
+    let error;
+    try {
+      generateGroupEmail('Test');
+    } catch (e) {
+      error = e;
+    }
+    assert.ok(error instanceof Error);
+  });
+});
+
+// Minimal test runner
+function describe(name, fn) {
+  console.log(name);
+  fn();
+}
+function it(name, fn) {
+  try {
+    fn();
+    console.log('  \u2714', name);
+  } catch (err) {
+    console.log('  \u2716', name);
+    console.error(err);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary
- extract and export `generateGroupEmail` utility for reuse
- add minimal Node-based lint and unit test harness
- wire up GitHub Actions CI to run lint and tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9be37b05c8320aaecf35ed0fb4a19