### PR TITLE
fix: validate single user email entries

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -40,7 +40,7 @@ This is the most important sheet. Each row represents a folder you want the scri
 For every row in `ManagedFolders`, the script creates a corresponding **user sheet**. The name of this sheet is shown in the `UserSheetName` column.
 
 *   **Purpose:** This is where you list the email addresses of the people who should have the specified role for that folder.
-*   **How to Use:** Simply add or remove email addresses in Column A of the relevant user sheet.
+*   **How to Use:** Simply add or remove email addresses in Column A of the relevant user sheet. Enter **exactly one valid email address per row** (for example, `user@example.com`). If a cell contains multiple addresses or anything other than a single valid email, the script will log an error and ignore that entry.
 
 ### 3. `UserGroups`
 


### PR DESCRIPTION
## Summary
- validate that each user row contains exactly one valid email address before syncing group memberships
- log detailed errors when rows contain multiple or malformed addresses and skip those entries
- update the user guide to clarify that only one email address should be entered per row
- add unit coverage that exercises the single-email validation and ensures trimmed addresses are accepted

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d37ed515a083208c696144ff60318b